### PR TITLE
mark a lot of methods as public, and reorganise

### DIFF
--- a/src/Geo.jl
+++ b/src/Geo.jl
@@ -1,5 +1,6 @@
 module Geo
 
+# Core tools with names you can access with e.g. Geo.func
 using DimensionalData
 using Extents
 using GeoDataFrames
@@ -8,14 +9,45 @@ using GeoInterface
 using GeometryOps
 using Proj
 using Rasters
+using GeoInterface.Wrappers
 
-import ArchGDAL
+# These packages are used under the hood for geometry data
 import GeoJSON
 import GeoParquet
-import NCDatasets
-import LibGEOS
 import Shapefile
-import ZarrDatasets
 import WellKnownGeometry
+
+# These are for loading raster/gridded data
+import NCDatasets
+import ZarrDatasets
+
+# ArchGDAL is used for everything
+import ArchGDAL
+
+# LibGeos is used for some additional methods GeometryOps doesn't have yet
+import LibGEOS
+
+# Clarifications: where multiple names are available
+using GeoDataFrames: read
+using GeoInterface: convert, extent # This extent knows how to calculate when not availablae
+
+# public
+# Mark all the names from `using Package` packages as public
+# This means accessing the docs wont have a warning.
+macro mark_public(modulename::Symbol)
+    mod = getfield(Geo, modulename)
+    namesvec = names(mod)
+    return Expr(:public, esc.(namesvec)...) 
+end
+
+@mark_public DimensionalData
+@mark_public Extents
+@mark_public GeoDataFrames
+@mark_public GeoFormatTypes
+@mark_public GeoInterface
+@mark_public GeometryOps
+@mark_public Proj
+@mark_public Rasters
+@mark_public Wrappers # GeoInterface.Wrappers
 
 end

--- a/src/Geo.jl
+++ b/src/Geo.jl
@@ -31,7 +31,8 @@ import LibGEOS
 using GeoDataFrames: read
 using GeoInterface: convert, extent # This extent knows how to calculate when not availablae
 
-# public
+
+# public declarations for juila 1.11 +
 # Mark all the names from `using Package` packages as public
 # This means accessing the docs wont have a warning.
 macro mark_public(modulename::Symbol)
@@ -39,15 +40,16 @@ macro mark_public(modulename::Symbol)
     namesvec = names(mod)
     return Expr(:public, esc.(namesvec)...) 
 end
-
-@mark_public DimensionalData
-@mark_public Extents
-@mark_public GeoDataFrames
-@mark_public GeoFormatTypes
-@mark_public GeoInterface
-@mark_public GeometryOps
-@mark_public Proj
-@mark_public Rasters
-@mark_public Wrappers # GeoInterface.Wrappers
+@static if VERSION >= v"1.11"
+    @mark_public DimensionalData
+    @mark_public Extents
+    @mark_public GeoDataFrames
+    @mark_public GeoFormatTypes
+    @mark_public GeoInterface
+    @mark_public GeometryOps
+    @mark_public Proj
+    @mark_public Rasters
+    @mark_public Wrappers # GeoInterface.Wrappers
+end
 
 end

--- a/src/Geo.jl
+++ b/src/Geo.jl
@@ -1,23 +1,23 @@
 module Geo
 
 # Core tools with names you can access with e.g. Geo.func
-using DimensionalData
 using Extents
-using GeoDataFrames
+using Proj
 using GeoFormatTypes
 using GeoInterface
-using GeometryOps
-using Proj
-using Rasters
-using GeoInterface.Wrappers
+using GeoInterface.Wrappers: Wrappers, Point, LineString, LinearRing, Polygon, MultiPoint, MultiLineString, MultiPolygon
 
 # These packages are used under the hood for geometry data
+import GeometryOps
+import GeoDataFrames
 import GeoJSON
 import GeoParquet
 import Shapefile
 import WellKnownGeometry
 
 # These are for loading raster/gridded data
+import Rasters
+import DimensionalData
 import NCDatasets
 import ZarrDatasets
 
@@ -28,28 +28,40 @@ import ArchGDAL
 import LibGEOS
 
 # Clarifications: where multiple names are available
-using GeoDataFrames: read
+using GeoDataFrames: read, write
 using GeoInterface: convert, extent # This extent knows how to calculate when not available
 
 
 # public declarations for julia 1.11 +
 # Mark all the names from `using Package` packages as public
 # This means accessing the docs wont have a warning.
-macro mark_public(modulename::Symbol)
+macro mark_public(modulename::Symbol, skip=Symbol[])
     mod = getfield(Geo, modulename)
-    namesvec = names(mod)
+    namesvec = setdiff(names(mod), skip)
     return Expr(:public, esc.(namesvec)...) 
 end
+
 @static if VERSION >= v"1.11"
-    @mark_public DimensionalData
-    @mark_public Extents
-    @mark_public GeoDataFrames
-    @mark_public GeoFormatTypes
-    @mark_public GeoInterface
-    @mark_public GeometryOps
-    @mark_public Proj
-    @mark_public Rasters
-    @mark_public Wrappers # GeoInterface.Wrappers
+
+@mark_public Extents
+@mark_public GeoFormatTypes
+@mark_public GeoInterface
+@mark_public GeometryOps
+@mark_public Proj
+@mark_public Rasters [:points, :dimwise]
+@mark_public Wrappers # GeoInterface.Wrappers
+
+# There seems to be a bug in the parser on at least 1.11
+# so that plain `public read, write` errors inside this if block
+# The solution is to just eval the expression
+
+# GeoDataFrames: mostly to avoid having createline/createpolygon etc here
+# Are the other methods we need?
+@eval Expr(:public, :read, :write)
+# DD just has too many things, and mostly we get them from Rasters
+@eval Expr(:public, :DimPoints, :DimSelectors, :DimIndices, DimTable)
+
 end
+
 
 end

--- a/src/Geo.jl
+++ b/src/Geo.jl
@@ -29,10 +29,10 @@ import LibGEOS
 
 # Clarifications: where multiple names are available
 using GeoDataFrames: read
-using GeoInterface: convert, extent # This extent knows how to calculate when not availablae
+using GeoInterface: convert, extent # This extent knows how to calculate when not available
 
 
-# public declarations for juila 1.11 +
+# public declarations for julia 1.11 +
 # Mark all the names from `using Package` packages as public
 # This means accessing the docs wont have a warning.
 macro mark_public(modulename::Symbol)


### PR DESCRIPTION
This PR adds a `@mark_public` macro and applies it to all the functions of the `using Package` package.

It also adds a bunch of comments and some import clarifications needed for a few of the public methods to actually work. There are likely a lot more of these.